### PR TITLE
Added very basic support for NDI Aurora trackers

### DIFF
--- a/wherepy/track/_tracker.py
+++ b/wherepy/track/_tracker.py
@@ -11,7 +11,7 @@ class Tracker(object):
         self.__connected = False
 
     def connect(self):
-        """Connect to tracking device.
+        """Connect to tracking device. No-op if already connected.
 
         :raise IOError: if no tracking device found
         """
@@ -20,7 +20,8 @@ class Tracker(object):
     def disconnect(self):
         """Disconnect from tracking device.
 
-        :raise IOError: if not connected
+        :raise IOError: if not connected, or if disconnection attempt
+        fails for some reason
         """
         raise NotImplementedError(Tracker.NOT_IMPLEMENTED_MSG)
 
@@ -42,7 +43,8 @@ class Tracker(object):
         """Capture a tool's pose.
 
         :rtype: ToolPose
-        :raise IOError: if not connected
+        :raise IOError: if not connected, or if capture fails
+        for any reason
         :raise ValueError: if `tool_id` not valid
         """
 

--- a/wherepy/track/_tracker.py
+++ b/wherepy/track/_tracker.py
@@ -4,6 +4,8 @@
 class Tracker(object):
     """This class is an abstraction for all supported trackers."""
 
+    NOT_IMPLEMENTED_MSG = 'To be implemented in device-linked class'
+
     def __init__(self):
         """Create an instance ready for connecting."""
         self.__connected = False
@@ -13,14 +15,14 @@ class Tracker(object):
 
         :raise IOError: if no tracking device found
         """
-        self.__raise_not_implemented()
+        raise NotImplementedError(Tracker.NOT_IMPLEMENTED_MSG)
 
     def disconnect(self):
         """Disconnect from tracking device.
 
         :raise IOError: if not connected
         """
-        self.__raise_not_implemented()
+        raise NotImplementedError(Tracker.NOT_IMPLEMENTED_MSG)
 
     @property
     def connected(self):
@@ -46,8 +48,4 @@ class Tracker(object):
 
         # pylint:disable=unused-argument
 
-        self.__raise_not_implemented()
-
-    def __raise_not_implemented(self):
-        """Internal method for unimplemented methods."""
-        raise NotImplementedError('To be implemented in device-linked class')
+        raise NotImplementedError(Tracker.NOT_IMPLEMENTED_MSG)

--- a/wherepy/track/ndi/__init__.py
+++ b/wherepy/track/ndi/__init__.py
@@ -1,0 +1,1 @@
+from ._tracker import Tracker

--- a/wherepy/track/ndi/__init__.py
+++ b/wherepy/track/ndi/__init__.py
@@ -1,1 +1,3 @@
+"""Classes that abstract NDI tracking devices and data."""
+
 from ._tracker import Tracker

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -118,7 +118,7 @@ class Tracker(wherepy.track.Tracker):
         if error != NDI_OKAY:
             raise IOError('Could not capture tool with ID {}. The error was:'
                           ' {}'.format(tool_id, ndiErrorString(error)))
-        if type(transform) == str:
+        if isinstance(transform, str):
             if transform.startswith('disabled') or transform.startswith('missing'):
                 raise ValueError('Could not capture tool with ID {}. The error was:'
                                  ' {}'.format(tool_id, transform))

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -1,5 +1,6 @@
 """Internal module that keeps the Tracker class for NDI devices."""
 
+from time import sleep
 import wherepy.track
 from pyndicapi import (ndiDeviceName, ndiProbe, ndiOpen, ndiClose,
                        ndiCommand, NDI_OKAY, ndiGetError, ndiErrorString,
@@ -64,6 +65,8 @@ class Tracker(wherepy.track.Tracker):
 
         # okay! set connected status
         self.__connected = True
+
+        sleep(1)  # artificial, to allow for initialisation
 
     def disconnect(self):
         if not self.connected:

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -126,7 +126,6 @@ class Tracker(wherepy.track.Tracker):
         # parse obtained transformation numbers
         quaternion = list(transform[:4])
         coordinates = list(transform[4:7])
-        error = transform[-1]
 
         # an artificial measure of quality based on a
         # maximum allowable error of 3 mm

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -126,7 +126,7 @@ class Tracker(wherepy.track.Tracker):
         # parse obtained transformation numbers
         quaternion = list(transform[:4])
         coordinates = list(transform[4:7])
-        error = float(transform[-1])
+        error = transform[-1]
 
         # an artificial measure of quality based on a
         # maximum allowable error of 3 mm
@@ -134,9 +134,17 @@ class Tracker(wherepy.track.Tracker):
         error_min, error_max = 0.00, 3.00  # mm
         error_range = error_max - error_min
 
-        quality = quality_max * (error_max - error)
-        quality += quality_min * (error - error_min)
-        quality /= error_range
+        try:
+            error = float(transform[-1])
+        except ValueError:
+            quality, error = quality_min, float('inf')
+        else:
+            if error > error_max:
+                quality = quality_min
+            else:
+                quality = quality_max * (error_max - error)
+                quality += quality_min * (error - error_min)
+                quality /= error_range
 
         # return the actual tool pose, at long last...
         return wherepy.track.ToolPose(

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -94,6 +94,10 @@ class Tracker(wherepy.track.Tracker):
         if not self.connected:
             raise IOError('Not connected to an NDI tracker')
 
+        if tool_id != self.tool_port_id:
+            raise ValueError('Tool ID {} not supported currently. Only {}'
+                             ' supported.'.format(tool_id, self.tool_port_id))
+
         command = 'GX:{:04x}'.format(NDI_XFORMS_AND_STATUS)
         ndiCommand(self.device, command)
         error = ndiGetError(self.device)

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -52,7 +52,12 @@ class Tracker(wherepy.track.Tracker):
         self.__connected = True
 
     def disconnect(self):
-        super(Tracker, self).disconnect()
+        if not self.connected:
+            raise IOError('Not connected to an NDI tracker')
+
+        ndiClose(self.device)
+        self.device = None
+        self.__connected = False
 
     def capture(self, tool_id):
         return super(Tracker, self).capture(tool_id)

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -68,6 +68,20 @@ class Tracker(wherepy.track.Tracker):
         if not self.connected:
             raise IOError('Not connected to an NDI tracker')
 
+        commands = [
+            'TSTOP:',
+            'PHSR:04',
+            'PDIS:{:02x}'.format(self.tool_port_id),
+            'COMM:00000',
+        ]
+        for command in commands:
+            ndiCommand(self.device, command)
+            error = ndiGetError(self.device)
+            if error != NDI_OKAY:
+                ndiClose(self.device)
+                raise IOError('Could not send command {} to NDI device. The error'
+                              ' was: {}'.format(command, ndiErrorString(error)))
+
         ndiClose(self.device)
         self.device = None
         self.__connected = False

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -9,7 +9,11 @@ from pyndicapi import (ndiDeviceName, ndiProbe, ndiOpen, ndiClose,
 
 
 class Tracker(wherepy.track.Tracker):
-    """This class is an abstraction for NDI trackers."""
+    """This class is an abstraction for NDI trackers.
+
+    Currently only NDI Aurora trackers with only one tool
+    plugged in are supported.
+    """
 
     SERIAL_PORTS_TO_TRY = 20
 

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -44,7 +44,7 @@ class Tracker(wherepy.track.Tracker):
         # try to start tracking
         reply = ndiCommand(self.device, 'TSTART:')
         error = ndiGetError(self.device)
-        if reply.lower().startswith('error') or error != NDI_OKAY:
+        if str(reply).lower().startswith('error') or error != NDI_OKAY:
             raise IOError('Could not start tracking. The error was:'
                           '\n{}'.format(ndiErrorString(error)))
 

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -1,17 +1,55 @@
 """Internal module that keeps the Tracker class for NDI devices."""
 
 import wherepy.track
+from pyndicapi import (ndiDeviceName, ndiProbe, ndiOpen, ndiClose,
+                       ndiCommand, NDI_OKAY, ndiGetError, ndiErrorString)
 
 
 class Tracker(wherepy.track.Tracker):
     """This class is an abstraction for NDI trackers."""
 
+    SERIAL_PORTS_TO_TRY = 20
+
     def __init__(self):
         """Create an instance ready for connecting."""
         super(Tracker, self).__init__()
+        self.device = None
 
     def connect(self):
-        super(Tracker, self).connect()
+        if self.connected:
+            return
+
+        # try to detect a connected NDI device
+        serial_port_name = ''
+        for serial_port_no in range(Tracker.SERIAL_PORTS_TO_TRY):
+            serial_port_name = ndiDeviceName(serial_port_no)
+            if not serial_port_name:
+                continue
+            result = ndiProbe(serial_port_name)
+            if result == NDI_OKAY:
+                break
+        if result != NDI_OKAY:
+            raise IOError('Could not detect any attached NDI device.'
+                          '\nPlease make sure:'
+                          '\n\t* an NDI device is connected'
+                          '\n\t* it is switched on'
+                          '\n\t* and you have sufficient access rights')
+
+        # try to connect to detected NDI device
+        self.device = ndiOpen(serial_port_name)
+        if not self.device:
+            raise IOError('Could not connect to NDI device on {}'
+                          ''.format(serial_port_name))
+
+        # try to start tracking
+        reply = ndiCommand(self.device, 'TSTART:')
+        error = ndiGetError(self.device)
+        if reply.lower().startswith('error') or error != NDI_OKAY:
+            raise IOError('Could not start tracking. The error was:'
+                          '\n{}'.format(ndiErrorString(error)))
+
+        # okay! set connected status
+        self.__connected = True
 
     def disconnect(self):
         super(Tracker, self).disconnect()

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -1,0 +1,20 @@
+"""Internal module that keeps the Tracker class for NDI devices."""
+
+import wherepy.track
+
+
+class Tracker(wherepy.track.Tracker):
+    """This class is an abstraction for NDI trackers."""
+
+    def __init__(self):
+        """Create an instance ready for connecting."""
+        super(Tracker, self).__init__()
+
+    def connect(self):
+        super(Tracker, self).connect()
+
+    def disconnect(self):
+        super(Tracker, self).disconnect()
+
+    def capture(self, tool_id):
+        return super(Tracker, self).capture(tool_id)


### PR DESCRIPTION
NDI Aurora trackers with only one plugged-in port are supported.

Closes #20 

Further work: #22 