### PR TITLE
Added support for dry-running

### DIFF
--- a/wherepy/app/__init__.py
+++ b/wherepy/app/__init__.py
@@ -39,6 +39,8 @@ def indicator_cli():
     parser = ArgumentParser()
     parser.add_argument('--pretty', help='Pretty formatting (uses Unicode characters)',
                         action='store_true')
+    parser.add_argument('-d', '--dry-run', help='Dry-run, useful for offline testing',
+                        action='store_true')
 
     args = parser.parse_args()
 

--- a/wherepy/app/__init__.py
+++ b/wherepy/app/__init__.py
@@ -18,6 +18,8 @@ def collector_cli():
     parser.add_argument('-o', '--session-log', help='Where to save captured poses',
                         type=check_non_existing,
                         metavar='FILE', required=True)
+    parser.add_argument('-d', '--dry-run', help='Dry-run, useful for offline testing',
+                        action='store_true')
 
     args = parser.parse_args()
 

--- a/wherepy/app/__init__.py
+++ b/wherepy/app/__init__.py
@@ -1,7 +1,8 @@
 """Functions that implement the functionality of console scripts."""
 
 from argparse import ArgumentParser
-from wherepy.track.ndi import Tracker
+import wherepy.track.ndi
+import wherepy.track.dummy
 from wherepy.io import SessionLog
 from ._utils import (check_positive_int, check_non_existing)
 from ._indicator import run_indicator_cli
@@ -23,7 +24,10 @@ def collector_cli():
 
     args = parser.parse_args()
 
-    tracker = Tracker()
+    if args.dry_run:
+        tracker = wherepy.track.dummy.Tracker()
+    else:
+        tracker = wherepy.track.ndi.Tracker()
     session_log = SessionLog(args.session_log)
     if not collect_n_poses_cli(tracker=tracker, num_poses=args.num_poses, session_log=session_log):
         exit(1)

--- a/wherepy/app/__init__.py
+++ b/wherepy/app/__init__.py
@@ -44,5 +44,8 @@ def indicator_cli():
 
     args = parser.parse_args()
 
-    tracker = Tracker()
+    if args.dry_run:
+        tracker = wherepy.track.dummy.Tracker()
+    else:
+        tracker = wherepy.track.ndi.Tracker()
     run_indicator_cli(tracker=tracker, update_rate=3, utf=args.pretty)

--- a/wherepy/track/__init__.py
+++ b/wherepy/track/__init__.py
@@ -2,3 +2,4 @@
 
 from ._tracker import Tracker
 from ._tool_pose import ToolPose
+from . import utils

--- a/wherepy/track/dummy/__init__.py
+++ b/wherepy/track/dummy/__init__.py
@@ -1,0 +1,3 @@
+"""Classes generating dummy data for offline testing."""
+
+from ._tracker import Tracker

--- a/wherepy/track/dummy/_tracker.py
+++ b/wherepy/track/dummy/_tracker.py
@@ -1,0 +1,62 @@
+"""Internal module that keeps the Tracker class for generating random data."""
+
+from random import (random, uniform)
+from math import sqrt
+import wherepy.track
+
+
+class Tracker(wherepy.track.Tracker):
+    """This class generates random tracking data."""
+
+    def __init__(self):
+        """Create an instance ready for connecting."""
+        super(Tracker, self).__init__()
+
+    def connect(self):
+        if self.connected:
+            return
+
+        self.__connected = True
+
+    def disconnect(self):
+        if not self.connected:
+            raise IOError('Not connected')
+
+        self.__connected = False
+
+    def capture(self, tool_id):
+        if not self.connected:
+            raise IOError('Not connected')
+
+        # generate a random quaternion
+        quaternion = [uniform(0.0, 1000.0) for _ in range(4)]
+        norm = reduce(lambda value_1, value_2: value_1 + value_2,
+                      map(lambda value: pow(value, 2), quaternion))
+        norm = sqrt(norm)
+        quaternion = list(map(lambda value: value / norm, quaternion))
+
+        # generate a random transform in a hypothetical
+        # tracking volume of 1 m3
+        coordinates = [uniform(-500.0, 500.0) for _ in range(3)]
+
+        # an artificial measure of quality based on a
+        # maximum allowable error of 0.8 mm
+        quality_min, quality_max = 0.00, 1.00  # %
+        error_min, error_max = 0.00, 0.80  # mm
+        error_range = error_max - error_min
+
+        # generate a random error value
+        error = random()
+
+        if error > error_max:
+            quality = quality_min
+        else:
+            quality = quality_max * (error_max - error)
+            quality += quality_min * (error - error_min)
+            quality /= error_range
+
+        # return a tool pose with the generated values
+        return wherepy.track.ToolPose(
+            tid=tool_id, quaternion=quaternion, coordinates=coordinates,
+            quality=quality, error=error,
+        )

--- a/wherepy/track/dummy/_tracker.py
+++ b/wherepy/track/dummy/_tracker.py
@@ -8,10 +8,6 @@ import wherepy.track
 class Tracker(wherepy.track.Tracker):
     """This class generates random tracking data."""
 
-    def __init__(self):
-        """Create an instance ready for connecting."""
-        super(Tracker, self).__init__()
-
     def connect(self):
         if self.connected:
             return

--- a/wherepy/track/dummy/_tracker.py
+++ b/wherepy/track/dummy/_tracker.py
@@ -1,6 +1,6 @@
 """Internal module that keeps the Tracker class for generating random data."""
 
-from random import (random, uniform)
+from random import (random, uniform, randrange)
 from math import sqrt
 import wherepy.track
 
@@ -25,8 +25,9 @@ class Tracker(wherepy.track.Tracker):
             raise IOError('Not connected')
 
         # should I stay or should I go? :)
-        if random() < 0.2:
-            raise IOError('I am moody 20 % of the time')
+        moody_perc = 20
+        if randrange(0, 100) < moody_perc:
+            raise IOError('I am moody {} % of the time'.format(moody_perc))
 
         # generate a random quaternion
         quaternion = [uniform(0.0, 1000.0) for _ in range(4)]

--- a/wherepy/track/dummy/_tracker.py
+++ b/wherepy/track/dummy/_tracker.py
@@ -28,6 +28,10 @@ class Tracker(wherepy.track.Tracker):
         if not self.connected:
             raise IOError('Not connected')
 
+        # should I stay or should I go? :)
+        if random() < 0.2:
+            raise IOError('I am moody 20 % of the time')
+
         # generate a random quaternion
         quaternion = [uniform(0.0, 1000.0) for _ in range(4)]
         norm = reduce(lambda value_1, value_2: value_1 + value_2,

--- a/wherepy/track/dummy/_tracker.py
+++ b/wherepy/track/dummy/_tracker.py
@@ -33,7 +33,7 @@ class Tracker(wherepy.track.Tracker):
         norm = reduce(lambda value_1, value_2: value_1 + value_2,
                       map(lambda value: pow(value, 2), quaternion))
         norm = sqrt(norm)
-        quaternion = list(map(lambda value: value / norm, quaternion))
+        quaternion = [value / norm for value in quaternion]
 
         # generate a random transform in a hypothetical
         # tracking volume of 1 m3

--- a/wherepy/track/dummy/_tracker.py
+++ b/wherepy/track/dummy/_tracker.py
@@ -40,21 +40,12 @@ class Tracker(wherepy.track.Tracker):
         # tracking volume of 1 m3
         coordinates = [uniform(-500.0, 500.0) for _ in range(3)]
 
-        # an artificial measure of quality based on a
-        # maximum allowable error of 0.8 mm
-        quality_min, quality_max = 0.00, 1.00  # %
-        error_min, error_max = 0.00, 0.80  # mm
-        error_range = error_max - error_min
-
         # generate a random error value
         error = random()
 
-        if error > error_max:
-            quality = quality_min
-        else:
-            quality = quality_max * (error_max - error)
-            quality += quality_min * (error - error_min)
-            quality /= error_range
+        # compute the corresponding quality, based on an artificial
+        # 0.8 mm maximum allowable error
+        quality = wherepy.track.utils.quality(error, 0.8)
 
         # return a tool pose with the generated values
         return wherepy.track.ToolPose(

--- a/wherepy/track/dummy/_tracker.py
+++ b/wherepy/track/dummy/_tracker.py
@@ -31,7 +31,7 @@ class Tracker(wherepy.track.Tracker):
         # generate a random quaternion
         quaternion = [uniform(0.0, 1000.0) for _ in range(4)]
         norm = reduce(lambda value_1, value_2: value_1 + value_2,
-                      map(lambda value: pow(value, 2), quaternion))
+                      [pow(value, 2) for value in quaternion])
         norm = sqrt(norm)
         quaternion = [value / norm for value in quaternion]
 

--- a/wherepy/track/dummy/_tracker.py
+++ b/wherepy/track/dummy/_tracker.py
@@ -45,7 +45,7 @@ class Tracker(wherepy.track.Tracker):
 
         # compute the corresponding quality, based on an artificial
         # 0.8 mm maximum allowable error
-        quality = wherepy.track.utils.quality(error, 0.8)
+        quality = wherepy.track.utils.quality(error, 0.8, 0.1)
 
         # return a tool pose with the generated values
         return wherepy.track.ToolPose(

--- a/wherepy/track/ndi/_tracker.py
+++ b/wherepy/track/ndi/_tracker.py
@@ -131,23 +131,12 @@ class Tracker(wherepy.track.Tracker):
         quaternion = list(transform[:4])
         coordinates = list(transform[4:7])
 
-        # an artificial measure of quality based on a
-        # maximum allowable error of 3 mm
-        quality_min, quality_max = 0.00, 1.00  # %
-        error_min, error_max = 0.00, 3.00  # mm
-        error_range = error_max - error_min
-
         try:
             error = float(transform[-1])
         except ValueError:
-            quality, error = quality_min, float('inf')
-        else:
-            if error > error_max:
-                quality = quality_min
-            else:
-                quality = quality_max * (error_max - error)
-                quality += quality_min * (error - error_min)
-                quality /= error_range
+            error = float('inf')
+
+        quality = wherepy.track.utils.quality(error, 3.00, 0.00)
 
         # return the actual tool pose, at long last...
         return wherepy.track.ToolPose(

--- a/wherepy/track/utils/__init__.py
+++ b/wherepy/track/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility functions for tracking data processing."""

--- a/wherepy/track/utils/__init__.py
+++ b/wherepy/track/utils/__init__.py
@@ -1,1 +1,14 @@
 """Utility functions for tracking data processing."""
+
+
+def quality(error, max_error, min_error=0.0):
+    """Compute a quality percentage, based on error.
+
+    :param error:
+    :param max_error: maximum allowable error
+    :param min_error: all smaller values than this yield
+    100 % quality
+    :return: a value btw. 0.00 and 1.00, representing a
+    percentage
+    """
+    return 0.0

--- a/wherepy/track/utils/__init__.py
+++ b/wherepy/track/utils/__init__.py
@@ -11,4 +11,14 @@ def quality(error, max_error, min_error=0.0):
     :return: a value btw. 0.00 and 1.00, representing a
     percentage
     """
-    return 0.0
+    min_quality, max_quality = 0.00, 1.00  # %
+
+    if error > max_error:
+        return min_quality
+
+    if error < min_error:
+        return max_quality
+
+    return (max_quality * (max_error - error) +
+            min_quality * (error - min_error)) /\
+           (max_error - min_error)


### PR DESCRIPTION
This is useful when testing e.g. display functionality offline.

* [x] a live test needs to be run as this PR will modify the NDI tracker code.

Closes #34 